### PR TITLE
Reset experiment ID when initialising

### DIFF
--- a/app.py
+++ b/app.py
@@ -332,6 +332,7 @@ def initialise(M):
     sysData[M]['Experiment']['ON']=0
     sysData[M]['Experiment']['cycles']=0
     sysData[M]['Experiment']['threadCount']=0
+    sysData[M]['Experiment']['experimentID'] = None
     sysData[M]['Experiment']['startTime']=' Waiting '
     sysData[M]['Experiment']['startTimeRaw']=0
     sysData[M]['OD']['ON']=0


### PR DESCRIPTION
Reset the experiment ID when device is initialised/reset, so the
display value can be reset as well.