### PR TITLE
API endpoints for remotely configuring experiments

### DIFF
--- a/app.py
+++ b/app.py
@@ -539,10 +539,13 @@ def setSysData():
     try:
         sysDataM = sysData[M]
     except KeyError as err:
-        return (jsonify({"error": f"invalid device {str(err)} in device payload"}), 400)
+        return (jsonify({"error": f"invalid device {str(err)} in device payload"}), 422)
 
+    # Reject if device M is currently active or if the device name does not match the setup
+    if sysDataM["Experiment"]["ON"] == 1:
+        return (jsonify({"error": f"device at position {M} is currently active"}), 422)
     if device_name != sysDataM["DeviceName"]:
-        return (jsonify({"error": f"incorrect device {device_name} at position {M}"}), 400)
+        return (jsonify({"error": f"incorrect device {device_name} at position {M}"}), 422)
 
     device_id = sysDataM["DeviceID"]
     addTerminal(M, f"SysData for {M} ({device_id}) configured by source: {source}")

--- a/app.py
+++ b/app.py
@@ -2263,7 +2263,6 @@ def ExperimentStartStop(M,value):
     value=int(value)
     #Turning it on involves keeping current pump directions,
     if (value and (sysData[M]['Experiment']['ON']==0)):
-
         sysData[M]['Experiment']['ON']=1
         addTerminal(M, 'Experiment on %s (%s) Started' % (M, sysData[M]['DeviceID']))
 
@@ -2290,6 +2289,9 @@ def ExperimentStartStop(M,value):
         sysDevices[M]['Experiment'].setDaemon(True)
         sysDevices[M]['Experiment'].start();
 
+        print(f"{datetime.now()} Experiment started on {M} ({sysData[M]['DeviceID']}): {sysData[M]['Experiment']['experimentID']}")
+        return jsonify({"experimentID": sysData[M]['Experiment']['experimentID']})
+
     else:
         sysData[M]['Experiment']['ON']=0
         sysData[M]['OD']['ON']=0
@@ -2299,7 +2301,8 @@ def ExperimentStartStop(M,value):
         SetOutputOn(M,'Stir',0)
         SetOutputOn(M,'Thermostat',0)
 
-    return ('', 204)
+        print(f"{datetime.now()} Experiment stopped on {M} ({sysData[M]['DeviceID']}): {sysData[M]['Experiment']['experimentID']}")
+        return ('', 204)
 
 
 

--- a/app.py
+++ b/app.py
@@ -49,7 +49,7 @@ handler.setFormatter(formatter)
 application.logger.addHandler(handler)
 
 lock=Lock()
-        
+
 #Initialise data structures.
 
 #Sysdata is a structure created for each device and contains the setup / measured data related to that device during an experiment. All of this information is passed into the user interface during an experiment.
@@ -109,7 +109,7 @@ sysData = {'M0' : {
 
 
 
-#SysDevices is unique to each device and is responsible for storing information required for the digital communications, and various automation funtions. These values are stored outside sysData since they are not passable into the HTML interface using the jsonify package.        
+#SysDevices is unique to each device and is responsible for storing information required for the digital communications, and various automation funtions. These values are stored outside sysData since they are not passable into the HTML interface using the jsonify package.
 sysDevices = {'M0' : {
     'AS7341' : {'device' : 0},
     'ThermometerInternal' : {'device' : 0},
@@ -124,16 +124,16 @@ sysDevices = {'M0' : {
     'Pump4' : {'thread' : 0,'threadCount' : 0, 'active' : 0},
     'Experiment' : {'thread' : 0},
     'Thermostat' : {'thread' : 0,'threadCount' : 0},
-    
+
 }}
 
 
 for M in ['M1','M2','M3','M4','M5','M6','M7']:
         sysData[M]=copy.deepcopy(sysData['M0'])
         sysDevices[M]=copy.deepcopy(sysDevices['M0'])
-        
 
-#sysItems stores information about digital addresses which is used as a reference for all devices.        
+
+#sysItems stores information about digital addresses which is used as a reference for all devices.
 sysItems = {
     'DAC' : {'LEDA' : '00000100','LEDB' : '00000000','LEDC' : '00000110','LEDD' : '00000001','LEDE' : '00000101','LEDF' : '00000011','LEDG' : '00000010','LASER650' : '00000111'},
     'Multiplexer' : {'device' : 0 , 'M0' : '00000001','M1' : '00000010','M2' : '00000100','M3' : '00001000','M4' : '00010000','M5' : '00100000','M6' : '01000000','M7' : '10000000'},
@@ -190,11 +190,11 @@ sysItems = {
         '0x13' : {'A' : 'FLICKER', 'B' : 'NIR'},
     }
 }
-   
+
 
 
 # This section of code is responsible for the watchdog circuit. The circuit is implemented in hardware on the control computer, and requires the watchdog pin be toggled low->high each second, otherwise it will power down all connected devices. This section is therefore critical to operation of the device.
-def runWatchdog():  
+def runWatchdog():
     #Watchdog toggling function which continually runs in a thread.
     global sysItems;
     if (sysItems['Watchdog']['ON']==1):
@@ -212,7 +212,7 @@ print(str(datetime.now()) + ' Starting watchdog')
 application.logger.info('Starting watchdog')
 sysItems['Watchdog']['thread']=Thread(target = runWatchdog, args=())
 sysItems['Watchdog']['thread'].setDaemon(True)
-sysItems['Watchdog']['thread'].start(); 
+sysItems['Watchdog']['thread'].start();
 
 
 
@@ -226,13 +226,13 @@ def initialise(M):
     for LED in ['LEDA','LEDB','LEDC','LEDD','LEDE','LEDF','LEDG']:
         sysData[M][LED]['target']=sysData[M][LED]['default']
         sysData[M][LED]['ON']=0
-    
+
     sysData[M]['UV']['target']=sysData[M]['UV']['default']
     sysData[M]['UV']['ON']=0
-    
+
     sysData[M]['LASER650']['target']=sysData[M]['LASER650']['default']
     sysData[M]['LASER650']['ON']=0
-    
+
     FP='FP1'
     sysData[M][FP]['ON']=0
     sysData[M][FP]['LED']="LEDB"
@@ -278,7 +278,7 @@ def initialise(M):
     sysData[M][FP]['Emit1Record']=[]
     sysData[M][FP]['Emit2Record']=[]
     sysData[M][FP]['Gain']="x10"
- 
+
     for PUMP in ['Pump1','Pump2','Pump3','Pump4']:
         sysData[M][PUMP]['default']=0.0;
         sysData[M][PUMP]['target']=sysData[M][PUMP]['default']
@@ -286,8 +286,8 @@ def initialise(M):
         sysData[M][PUMP]['direction']=1.0
         sysDevices[M][PUMP]['threadCount']=0
         sysDevices[M][PUMP]['active']=0
-    
-    
+
+
     sysData[M]['Heat']['default']=0;
     sysData[M]['Heat']['target']=sysData[M]['Heat']['default']
     sysData[M]['Heat']['ON']=0
@@ -300,35 +300,35 @@ def initialise(M):
 
     sysData[M]['Stir']['target']=sysData[M]['Stir']['default']
     sysData[M]['Stir']['ON']=0
-    
+
     sysData[M]['Light']['target']=sysData[M]['Light']['default']
     sysData[M]['Light']['ON']=0
     sysData[M]['Light']['Excite']='LEDD'
-    
+
     sysData[M]['Custom']['Status']=sysData[M]['Custom']['default']
     sysData[M]['Custom']['ON']=0
     sysData[M]['Custom']['Program']='C1'
-    
+
     sysData[M]['Custom']['param1']=0.0
     sysData[M]['Custom']['param2']=0.0
     sysData[M]['Custom']['param3']=0.0
-    
+
     sysData[M]['OD']['current']=0.0
     sysData[M]['OD']['target']=sysData[M]['OD']['default'];
     sysData[M]['OD0']['target']=65000.0
     sysData[M]['OD0']['raw']=65000.0
     sysData[M]['OD']['device']='LASER650'
     #sysData[M]['OD']['device']='LEDA'
-    
+
     #if (M=='M0'):
     #    sysData[M]['OD']['device']='LEDA'
-    
-    
+
+
     sysData[M]['Volume']['target']=20.0
-    
+
     clearTerminal(M)
     addTerminal(M,'System for %s (%s) Initialised' % (M, sysData[M]['DeviceID']))
-  
+
     sysData[M]['Experiment']['ON']=0
     sysData[M]['Experiment']['cycles']=0
     sysData[M]['Experiment']['threadCount']=0
@@ -357,7 +357,7 @@ def initialise(M):
     sysData[M]['ThermometerInternal']['current']=0.0
     sysData[M]['ThermometerExternal']['current']=0.0
     sysData[M]['ThermometerIR']['current']=0.0
- 
+
     sysData[M]['time']['record']=[]
     sysData[M]['OD']['record']=[]
     sysData[M]['OD']['targetrecord']=[]
@@ -371,7 +371,7 @@ def initialise(M):
     sysData[M]['ThermometerExternal']['record']=[]
     sysData[M]['ThermometerIR']['record']=[]
     sysData[M]['Thermostat']['record']=[]
-	
+
     sysData[M]['GrowthRate']['record']=[]
 
     sysDevices[M]['ThermometerInternal']['device']=I2C.get_i2c_device(0x18,2) #Get Thermometer on Bus 2!!!
@@ -383,12 +383,12 @@ def initialise(M):
     sysDevices[M]['Pumps']['frequency']=0x1e #200Hz PWM frequency
     sysDevices[M]['PWM']['device']=I2C.get_i2c_device(0x60,2) #Get OD Chip on Bus 2!!!!!
     sysDevices[M]['PWM']['startup']=0
-    sysDevices[M]['PWM']['frequency']=0x03# 0x14 = 300hz, 0x03 is 1526 Hz PWM frequency for fan/LEDs, maximum possible. Potentially dial this down if you are getting audible ringing in the device! 
+    sysDevices[M]['PWM']['frequency']=0x03# 0x14 = 300hz, 0x03 is 1526 Hz PWM frequency for fan/LEDs, maximum possible. Potentially dial this down if you are getting audible ringing in the device!
     #There is a tradeoff between large frequencies which can make capacitors in the 6V power regulation oscillate audibly, and small frequencies which result in the number of LED "ON" cycles varying during measurements.
     sysDevices[M]['ThermometerIR']['device']=smbus.SMBus(bus=2) #Set up SMBus thermometer
-    sysDevices[M]['ThermometerIR']['address']=0x5a 
-    
-    
+    sysDevices[M]['ThermometerIR']['address']=0x5a
+
+
     # This section of commented code is used for testing I2C communication integrity.
     # sysData[M]['present']=1
     # getData=I2CCom(M,'ThermometerInternal',1,16,0x05,0,0)
@@ -399,7 +399,7 @@ def initialise(M):
     #         print(str(i))
     #     sysDevices[M]['ThermometerInternal']['device'].readU8(int(0x05))
     # getData=I2CCom(M,which,1,16,0x05,0,0)
-    
+
 
     scanDevices(M)
     # TODO remove this from here!
@@ -433,7 +433,7 @@ def initialise(M):
 
 def initialiseAll():
     # Initialisation function which runs at when software is started for the first time.
-    sysItems['Multiplexer']['device']=I2C.get_i2c_device(0x74,2) 
+    sysItems['Multiplexer']['device']=I2C.get_i2c_device(0x74,2)
     sysItems['FailCount']=0
     time.sleep(2.0) #This wait is to allow the watchdog circuit to boot.
     check_config_value(config_key='CONTINUOUS_STIRRING', default_value=False)
@@ -450,15 +450,15 @@ def initialiseAll():
     for M in ['M0','M1','M2','M3','M4','M5','M6','M7']:
         initialise(M)
     scanDevices("all")
-    
-    
-  
-    
+
+
+
+
 def turnEverythingOff(M):
     # Function which turns off all actuation/hardware.
     for LED in ['LEDA','LEDB','LEDC','LEDD','LEDE','LEDF','LEDG']:
         sysData[M][LED]['ON']=0
-        
+
     sysData[M]['LASER650']['ON']=0
     sysData[M]['Pump1']['ON']=0
     sysData[M]['Pump2']['ON']=0
@@ -467,8 +467,8 @@ def turnEverythingOff(M):
     sysData[M]['Stir']['ON']=0
     sysData[M]['Heat']['ON']=0
     sysData[M]['UV']['ON']=0
-    
-    I2CCom(M,'DAC',0,8,int('00000000',2),int('00000000',2),0)#Sets all DAC Channels to zero!!! 
+
+    I2CCom(M,'DAC',0,8,int('00000000',2),int('00000000',2),0)#Sets all DAC Channels to zero!!!
     setPWM(M,'PWM',sysItems['All'],0,0)
 
     if application.config['TWO_PUMPS_PER_DEVICE']:
@@ -477,7 +477,7 @@ def turnEverythingOff(M):
         chibios_to_shut_down = [0, 1, 2, 4, 5, 6, 7]
     if int(M[1]) in chibios_to_shut_down:
         setPWM(M=M, device='Pumps', channels=sysItems['All'], fraction=0, ConsecutiveFails=0)
-    
+
     SetOutputOn(M,'Stir',0)
     SetOutputOn(M,'Thermostat',0)
     SetOutputOn(M,'Heat',0)
@@ -486,17 +486,17 @@ def turnEverythingOff(M):
     SetOutputOn(M,'Pump2',0)
     SetOutputOn(M,'Pump3',0)
     SetOutputOn(M,'Pump4',0)
-    
 
 
- 
+
+
 
 @application.route('/')
 def index():
-    #Function responsible for sending appropriate device's data to user interface. 
+    #Function responsible for sending appropriate device's data to user interface.
     global sysData
     global sysItems
-    
+
     outputdata=sysData[sysItems['UIDevice']]
     # sending the current beaglebone's name to UI
     outputdata['beaglebone_name'] = application.config['BEAGLEBONE_NAME']
@@ -506,7 +506,7 @@ def index():
             else:
                 outputdata['presentDevices'][M]=0
     return render_template('index.html',**outputdata)
-    
+
 @application.route('/getSysdata/')
 def getSysdata():
     #Similar to function above, packages data to be sent to UI.
@@ -529,7 +529,7 @@ def changeDevice(M):
     if sysData[M]['present']==1:
         for Mb in ['M0','M1','M2','M3','M4','M5','M6','M7']:
             sysData[Mb]['UIDevice']=M
-        
+
         sysItems['UIDevice']=M
 
     return ('', 204)
@@ -539,14 +539,14 @@ def scanDevices(which):
     #Scans to decide which devices are plugged in/on. Does this by trying to communicate with their internal thermometers (if this communication failes, software assumes device is not present)
     global sysData
     which=str(which)
-    
+
     if which=="all":
         for M in ['M0','M1','M2','M3','M4','M5','M6','M7']:
             sysData[M]['present']=1
-            I2CCom(M,'ThermometerInternal',1,16,0x05,0,0) #We arbitrarily poll the thermometer to see if anything is plugged in! 
+            I2CCom(M,'ThermometerInternal',1,16,0x05,0,0) #We arbitrarily poll the thermometer to see if anything is plugged in!
             sysData[M]['DeviceID']=GetID(M)
-    else: 
-        
+    else:
+
         sysData[which]['present']=1
         I2CCom(which,'ThermometerInternal',1,16,0x05,0,0)
         sysData[which]['DeviceID']=GetID(which)
@@ -565,9 +565,9 @@ def GetID(M):
         pt3=str(I2CCom(M,'ThermometerIR',1,0,0x3E,0,1))
         pt4=str(I2CCom(M,'ThermometerIR',1,0,0x3F,0,1))
         ID = pt1+pt2+pt3+pt4
-        
+
     return ID
-    
+
 
 def addTerminal(M,strIn):
     #Responsible for adding a new line to the terminal in the UI.
@@ -576,7 +576,7 @@ def addTerminal(M,strIn):
     now=datetime.now()
     timeString=now.strftime("%Y-%m-%d %H:%M:%S ")
     sysData[M]['Terminal']['text']=timeString + ' - ' +  str(strIn) + '</br>' + sysData[M]['Terminal']['text']
-    
+
 @application.route("/ClearTerminal/<M>",methods=['POST'])
 def clearTerminal(M):
     #Deletes everything from the terminal.
@@ -584,11 +584,11 @@ def clearTerminal(M):
     M=str(M)
     if (M=="0"):
         M=sysItems['UIDevice']
-        
+
     sysData[M]['Terminal']['text']=''
     addTerminal(M,'Terminal on %s (%s) Cleared' % (M, sysData[M]['DeviceID']))
-    return ('', 204)   
-    
+    return ('', 204)
+
 
 
 @application.route("/SetFPMeasurement/<item>/<Excite>/<Base>/<Emit1>/<Emit2>/<Gain>",methods=['POST'])
@@ -601,23 +601,23 @@ def SetFPMeasurement(item,Excite,Base,Emit1,Emit2,Gain):
     Emit2=str(Emit2)
     Gain=str(Gain)
     M=sysItems['UIDevice']
-    
+
     if sysData[M][FP]['ON']==1:
         sysData[M][FP]['ON']=0
         return ('', 204)
-    else: 
+    else:
         sysData[M][FP]['ON']=1
         sysData[M][FP]['LED']=Excite
         sysData[M][FP]['BaseBand']=Base
         sysData[M][FP]['Emit1Band']=Emit1
         sysData[M][FP]['Emit2Band']=Emit2
         sysData[M][FP]['Gain']=Gain
-        return ('', 204)  
-     
+        return ('', 204)
 
-        
-    
-    
+
+
+
+
 
 @application.route("/SetOutputTarget/<item>/<M>/<value>",methods=['POST'])
 def SetOutputTarget(M,item, value):
@@ -635,17 +635,17 @@ def SetOutputTarget(M,item, value):
         value=sysData[M][item]['min']
     if (value>sysData[M][item]['max']):
         value=sysData[M][item]['max']
-        
+
     sysData[M][item]['target']=value
-    
+
     if(sysData[M][item]['ON']==1 and not(item=='OD' or item=='Thermostat')): #Checking to see if our item is already running, in which case
         SetOutputOn(M,item,0) #we turn it off and on again to restart at new rate.
         SetOutputOn(M,item,1)
-    return ('', 204)    
-    
+    return ('', 204)
 
 
-    
+
+
 @application.route("/SetOutputOn/<item>/<force>/<M>",methods=['POST'])
 def SetOutputOn(M,item,force):
     #General function used to switch an output on or off.
@@ -671,17 +671,17 @@ def SetOutputOn(M,item,force):
         sysData[M][item]['ON']=0;
         SetOutput(M,item)
         return ('', 204)
-    
+
     #Elsewise this is doing a flip operation (i.e. changes to opposite state to that which it is currently in)
     if (sysData[M][item]['ON']==0):
         sysData[M][item]['ON']=1
         SetOutput(M,item)
-        return ('', 204)    
-    
+        return ('', 204)
+
     else:
         sysData[M][item]['ON']=0;
         SetOutput(M,item)
-        return ('', 204)    
+        return ('', 204)
 
 
 def SetOutput(M,item):
@@ -691,7 +691,7 @@ def SetOutput(M,item):
     global sysDevices
     M=str(M)
     #We go through each different item and set it going as appropriate.
-    if(item=='Stir'): 
+    if(item=='Stir'):
         #Stirring is initiated at a high speed for a couple of seconds to prevent the stir motor from stalling (e.g. if it is started at an initial power of 0.3)
         if (sysData[M][item]['target']*float(sysData[M][item]['ON'])>0):
             setPWM(M,'PWM',sysItems[item],1.0*float(sysData[M][item]['ON']),0) # This line is to just get stirring started briefly.
@@ -700,14 +700,14 @@ def SetOutput(M,item):
             if (sysData[M][item]['target']>0.4 and sysData[M][item]['ON']==1):
                 setPWM(M,'PWM',sysItems[item],0.5*float(sysData[M][item]['ON']),0) # This line is to just get stirring started briefly.
                 time.sleep(0.75)
-            
+
             if (sysData[M][item]['target']>0.8 and sysData[M][item]['ON']==1):
                 setPWM(M,'PWM',sysItems[item],0.7*float(sysData[M][item]['ON']),0) # This line is to just get stirring started briefly.
                 time.sleep(0.75)
 
         setPWM(M,'PWM',sysItems[item],sysData[M][item]['target']*float(sysData[M][item]['ON']),0)
-        
-        
+
+
     elif(item=='Heat'):
         setPWM(M,'PWM',sysItems[item],sysData[M][item]['target']*float(sysData[M][item]['ON']),0)
     elif(item=='UV'):
@@ -716,12 +716,12 @@ def SetOutput(M,item):
         sysDevices[M][item]['thread']=Thread(target = Thermostat, args=(M,item))
         sysDevices[M][item]['thread'].setDaemon(True)
         sysDevices[M][item]['thread'].start();
-        
-    elif (item=='Pump1' or item=='Pump2' or item=='Pump3' or item=='Pump4'): 
+
+    elif (item=='Pump1' or item=='Pump2' or item=='Pump3' or item=='Pump4'):
         if (sysData[M][item]['target']==0):
             sysData[M][item]['ON']=0
         sysDevices[M][item]['thread']=Thread(target = PumpModulation, args=(M,item))
-        
+
         sysDevices[M][item]['thread'].setDaemon(True)
         sysDevices[M][item]['thread'].start();
 
@@ -731,14 +731,14 @@ def SetOutput(M,item):
     elif (item=='Zigzag'):
         sysData[M]['Zigzag']['target']=5.0
         sysData[M]['Zigzag']['SwitchPoint']=sysData[M]['Experiment']['cycles']
-    
+
     elif (item=='LEDA' or item=='LEDB' or item=='LEDC' or item=='LEDD' or item=='LEDE' or item=='LEDF' or item=='LEDG'):
         setPWM(M,'PWM',sysItems[item],sysData[M][item]['target']*float(sysData[M][item]['ON']),0)
-        
+
     else: #This is if we are setting the DAC. All should be in range [0,1]
         register = int(sysItems['DAC'][item],2)
-        
-        value=sysData[M][item]['target']*float(sysData[M][item]['ON']) 
+
+        value=sysData[M][item]['target']*float(sysData[M][item]['ON'])
         if (value==0):
             value=0
         else:
@@ -750,13 +750,13 @@ def SetOutput(M,item):
         toWrite1=int(toWrite[0:8],2)
         toWrite2=int(toWrite[8:16],2)
         I2CCom(M,'DAC',0,8,toWrite1,toWrite2,0)
-       
-        
-        
-    
-    
-        
-  
+
+
+
+
+
+
+
 def PumpModulation(M,item):
     #Responsible for turning pumps on/off with an appropriate duty cycle. They are turned on for a fraction of each ~1minute cycle to achieve low pump rates.
     global sysData
@@ -785,10 +785,10 @@ def PumpModulation(M,item):
 
     sysDevices[M][item]['threadCount']=(sysDevices[M][item]['threadCount']+1)%100 #Index of the particular thread running.
     currentThread=sysDevices[M][item]['threadCount']
-    
+
     while (sysDevices[M][item]['active']==1): #Idea is we will wait here if a previous thread on this pump is already running. Potentially all this 'active' business could be removed from this fuction.
         time.sleep(0.02)
-        
+
     if (abs(sysData[M][item]['target']*sysData[M][item]['ON'])!=1 and currentThread==sysDevices[M][item]['threadCount']): #In all cases we turn things off to begin
         sysDevices[M][item]['active']=1
         setPWM(MB,'Pumps',sysItems[itemB]['In1'],0.0*float(sysData[M][item]['ON']),0)
@@ -798,18 +798,18 @@ def PumpModulation(M,item):
         sysDevices[M][item]['active']=0
     if (sysData[M][item]['ON']==0):
         return
-    
+
     Time1=datetime.now()
     cycletime=sysData[M]['Experiment']['cycleTime']*1.05 #We make this marginally longer than the experiment cycle time to avoid too much chaos when you come back around to pumping again.
-    
+
     Ontime=cycletime*abs(sysData[M][item]['target'])
-    
+
     # Decided to remove the below section in order to prevent media buildup in the device if you are pumping in very rapidly. This check means that media is removed, then added. Removing this code means these happen simultaneously.
     #if (item=="Pump1" and abs(sysData[M][item]['target'])<0.3): #Ensuring we run Pump1 after Pump2.
     #    waittime=cycletime*abs(sysData[M]['Pump2']['target']) #We want to wait until the output pump has stopped, otherwise you are very inefficient with your media since it will be pumping out the fresh media fromthe top of the test tube right when it enters.
-    #    time.sleep(waittime+1.0)  
-        
-    
+    #    time.sleep(waittime+1.0)
+
+
     if (sysData[M][item]['target']>0 and currentThread==sysDevices[M][item]['threadCount']): #Turning on pumps in forward direction
         sysDevices[M][item]['active']=1
         setPWM(MB,'Pumps',sysItems[itemB]['In1'],1.0*float(sysData[M][item]['ON']),0)
@@ -820,9 +820,9 @@ def PumpModulation(M,item):
         setPWM(MB,'Pumps',sysItems[itemB]['In1'],0.0*float(sysData[M][item]['ON']),0)
         setPWM(MB,'Pumps',sysItems[itemB]['In2'],1.0*float(sysData[M][item]['ON']),0)
         sysDevices[M][item]['active']=0
-  
+
     time.sleep(Ontime)
-    
+
     if(abs(sysData[M][item]['target'])!=1 and currentThread==sysDevices[M][item]['threadCount']): #Turning off pumps at appropriate time.
         sysDevices[M][item]['active']=1
         setPWM(MB,'Pumps',sysItems[itemB]['In1'],0.0*float(sysData[M][item]['ON']),0)
@@ -830,21 +830,21 @@ def PumpModulation(M,item):
         setPWM(MB,'Pumps',sysItems[itemB]['In1'],0.0*float(sysData[M][item]['ON']),0)
         setPWM(MB,'Pumps',sysItems[itemB]['In2'],0.0*float(sysData[M][item]['ON']),0)
         sysDevices[M][item]['active']=0
-    
+
     Time2=datetime.now()
     elapsedTime=Time2-Time1
     elapsedTimeSeconds=round(elapsedTime.total_seconds(),2)
     Offtime=cycletime-elapsedTimeSeconds
     if (Offtime>0.0):
-        time.sleep(Offtime)   
-    
-    
+        time.sleep(Offtime)
+
+
     if (sysData[M][item]['ON']==1 and sysDevices[M][item]['threadCount']==currentThread): #If pumps need to keep going, this starts a new pump thread.
         sysDevices[M][item]['thread']=Thread(target = PumpModulation, args=(M,item))
         sysDevices[M][item]['thread'].setDaemon(True)
         sysDevices[M][item]['thread'].start();
-    
-        
+
+
 
 
 
@@ -858,17 +858,17 @@ def Thermostat(M,item):
     ON=sysData[M][item]['ON']
     sysDevices[M][item]['threadCount']=(sysDevices[M][item]['threadCount']+1)%100
     currentThread=sysDevices[M][item]['threadCount']
-    
+
     if (ON==0):
         SetOutputOn(M,'Heat',0)
         return
-    
+
     MeasureTemp(M,'IR') #Measures temperature - note that this may be happening DURING stirring.
 
     CurrentTemp=sysData[M]['ThermometerIR']['current']
     TargetTemp=sysData[M]['Thermostat']['target']
     LastTemp=sysData[M]['Thermostat']['last']
-    
+
     #MPC Controller Component
     MediaTemp=sysData[M]['ThermometerExternal']['current']
     MPC=0
@@ -877,8 +877,8 @@ def Thermostat(M,item):
         Pumping=sysData[M]['Pump1']['target']*float(sysData[M]['Pump1']['ON'])*float(sysData[M]['OD']['ON'])
         Gain=2.5
         MPC=Gain*Tdiff*Pumping
-        
-        
+
+
     #PI Controller Component
     e=TargetTemp-CurrentTemp
     dt=sysData[M]['Thermostat']['cycleTime']
@@ -888,37 +888,37 @@ def Thermostat(M,item):
         P=0.25*e
     else:
         P=0.5*e;
-    
+
     if (abs(TargetTemp-LastTemp)>2.0): #This resets integrator if we make a big jump in set point.
         I=0.0
     elif(I<0.0):
         I=0.0
     elif (I>1.0):
         I=1.0
-    
+
     sysData[M]['Thermostat']['Integral']=I
 
     U=P+I+MPC
-    
+
     if(U>1.0):
         U=1.0
         sysData[M]['Heat']['target']=U
         sysData[M]['Heat']['ON']=1
-    elif(U<0):  
+    elif(U<0):
         U=0
         sysData[M]['Heat']['target']=U
         sysData[M]['Heat']['ON']=0
     else:
         sysData[M]['Heat']['target']=U
         sysData[M]['Heat']['ON']=1
-    
+
     sysData[M]['Thermostat']['last']=sysData[M]['Thermostat']['target']
-   
+
     SetOutput(M,'Heat')
-    
-    time.sleep(dt)  
-        
-    
+
+    time.sleep(dt)
+
+
     if (sysData[M][item]['ON']==1 and sysDevices[M][item]['threadCount']==currentThread):
         sysDevices[M][item]['thread']=Thread(target = Thermostat, args=(M,item))
         sysDevices[M][item]['thread'].setDaemon(True)
@@ -927,13 +927,13 @@ def Thermostat(M,item):
         sysData[M]['Heat']['ON']=0
         sysData[M]['Heat']['target']=0
         SetOutput(M,'Heat')
-        
-        
-    
-    
-    
-    
-        
+
+
+
+
+
+
+
 
 @application.route("/Direction/<item>/<M>",methods=['POST'])
 def direction(M,item):
@@ -946,10 +946,10 @@ def direction(M,item):
     if (sysData[M]['OD']['ON']==1):
             sysData[M][item]['direction']=-1.0*sysData[M][item]['direction']
 
-    return ('', 204)  
-    
+    return ('', 204)
 
-    
+
+
 def AS7341Read(M,Gain,ISteps,reset):
     #Responsible for reading data from the spectrometer.
     global sysItems
@@ -974,11 +974,11 @@ def AS7341Read(M,Gain,ISteps,reset):
         I2CCom(M,'AS7341',0,8,int(0x80),int(0x01),0)  #Turns power on with spectral measurement disabled
 
     I2CCom(M,'AS7341',0,8,int(0xAF),int(0x10),0) #Tells it we are going to now write SMUX configuration to RAM
-    
-    
+
+
     #I2CCom(M,'AS7341',0,100,int(0x00),int(0x00),0) #Forces AS7341SMUX to run since length is 100.
     AS7341SMUX(M,'AS7341',0,0)
-    
+
     I2CCom(M,'AS7341',0,8,int(0x80),int(0x11),0)  #Runs SMUX command (i.e. cofigures SMUX with data from ram)
     time.sleep(0.001)
     I2CCom(M,'AS7341',0,8,int(0x81),ISteps,0)  #Sets number of integration steps of length 2.78ms Max ISteps is 255
@@ -988,8 +988,8 @@ def AS7341Read(M,Gain,ISteps,reset):
     #I2CCom(M,'AS7341',0,8,int(0x70),int(0x00),0)  #Sets integration mode SPM (normal mode)
     #Above is default of 0x70!
     I2CCom(M,'AS7341',0,8,int(0x80),int(0x0B),0)  #Starts spectral measurement, with WEN (wait between measurements feature) enabled.
-    time.sleep((ISteps+1)*0.0028 + 0.2) #Wait whilst integration is done and results are processed. 
-    
+    time.sleep((ISteps+1)*0.0028 + 0.2) #Wait whilst integration is done and results are processed.
+
     ASTATUS=int(I2CCom(M,'AS7341',1,8,0x94,0x00,0)) #Get measurement status, including saturation details.
     C0_L=int(I2CCom(M,'AS7341',1,8,0x95,0x00,0))
     C0_H=int(I2CCom(M,'AS7341',1,8,0x96,0x00,0))
@@ -1006,7 +1006,7 @@ def AS7341Read(M,Gain,ISteps,reset):
 
     I2CCom(M,'AS7341',0,8,int(0x80),int(0x01),0)  #Stops spectral measurement, leaves power on.
 
-    #Status2=int(I2CCom(M,'AS7341',1,8,0xA3,0x00,0)) #Reads system status at end of spectral measursement. 
+    #Status2=int(I2CCom(M,'AS7341',1,8,0xA3,0x00,0)) #Reads system status at end of spectral measursement.
     #print(str(ASTATUS))
     #print(str(Status2))
 
@@ -1023,10 +1023,10 @@ def AS7341Read(M,Gain,ISteps,reset):
         print(str(datetime.now()) + info_msg) #Not sure if this saturation check above actually works correctly...
         application.logger.info(info_msg)
     return 0
-        
+
 
 def AS7341SMUX(M,device,data1,data2):
-    #Sets up the ADC multiplexer on the spectrometer, this is responsible for connecting photodiodes to amplifier/adc circuits within the device. 
+    #Sets up the ADC multiplexer on the spectrometer, this is responsible for connecting photodiodes to amplifier/adc circuits within the device.
     #The spectrometer has only got 6 ADCs but >6 photodiodes channels, hence you need to select a subset of photodiodes to measure with each shot. The relative gain does change slightly (1-2%) between ADCs.
     global sysItems
     global sysData
@@ -1054,11 +1054,11 @@ def AS7341SMUX(M,device,data1,data2):
 
 @application.route("/GetSpectrum/<Gain>/<M>",methods=['POST'])
 def GetSpectrum(M,Gain):
-    #Measures entire spectrum, i.e. every different photodiode, which requires 2 measurement shots. 
+    #Measures entire spectrum, i.e. every different photodiode, which requires 2 measurement shots.
     Gain=int(Gain[1:])
     global sysData
     global sysItems
-    M=str(M)   
+    M=str(M)
     if (M=="0"):
         M=sysItems['UIDevice']
     out=GetLight(M,['nm410','nm440','nm470','nm510','nm550','nm583'],Gain,255)
@@ -1073,14 +1073,14 @@ def GetSpectrum(M,Gain):
     sysData[M]['AS7341']['spectrum']['nm670']=out2[1]
     sysData[M]['AS7341']['spectrum']['CLEAR']=out2[2]
     sysData[M]['AS7341']['spectrum']['NIR']=out2[3]
-    
-        
-    return ('', 204)   
-    
 
 
-        
-    
+    return ('', 204)
+
+
+
+
+
 def GetLight(M,wavelengths,Gain,ISteps):
     #Runs spectrometer measurement and puts data into appropriate structure.
     global sysData
@@ -1091,13 +1091,13 @@ def GetLight(M,wavelengths,Gain,ISteps):
     index=1;
     for wavelength in wavelengths:
         if wavelength != "OFF":
-            sysData[M]['AS7341']['channels'][wavelength]=index #Now assign ADCs to each of the channel where needed. 
+            sysData[M]['AS7341']['channels'][wavelength]=index #Now assign ADCs to each of the channel where needed.
         index=index+1
 
     success=0
     while success<2:
         try:
-            AS7341Read(M,Gain,ISteps,success) 
+            AS7341Read(M,Gain,ISteps,success)
             success=2
         except:
             warn_msg = 'AS7341 measurement failed on %s (%s)' % (M, sysData[M]['DeviceID'])
@@ -1144,7 +1144,7 @@ def GetTransmission(M,item,wavelengths,Gain,ISteps):
 @application.route("/SetCustom/<Program>/<Status>",methods=['POST'])
 def SetCustom(Program,Status):
     #Turns a custom program on/off.
-	
+
     global sysData
     M=sysItems['UIDevice']
     item="Custom"
@@ -1158,11 +1158,11 @@ def SetCustom(Program,Status):
         sysData[M][item]['param2']=0.0
         sysData[M][item]['param3']=0.0
     return('',204)
-		
-        
+
+
 def CustomProgram(M):
     #Runs a custom program, some examples are included. You can remove/edit this function as you see fit.
-    #Note that the custom programs (as set up at present) use an external .csv file with input parameters. THis is done to allow these parameters to easily be varied on the fly. 
+    #Note that the custom programs (as set up at present) use an external .csv file with input parameters. THis is done to allow these parameters to easily be varied on the fly.
     global sysData
     M=str(M)
     program=sysData[M]['Custom']['Program']
@@ -1177,7 +1177,7 @@ def CustomProgram(M):
 
     if (program=="C1"): #Optogenetic Integral Control Program
         integral=0.0 #Integral in integral controller
-        green=0.0 #Intensity of Green actuation 
+        green=0.0 #Intensity of Green actuation
         red=0.0 #Intensity of red actuation.
         GFPNow=sysData[M]['FP1']['Emit1']
         GFPTarget=sysData[M]['Custom']['Status'] #This is the controller setpoint.
@@ -1185,7 +1185,7 @@ def CustomProgram(M):
         if error>0.0075:
             green=1.0
             red=0.0
-            sysData[M]['Custom']['param3']=0.0 
+            sysData[M]['Custom']['param3']=0.0
         elif error<-0.0075:
             green=0.0
             red=1.0
@@ -1198,7 +1198,7 @@ def CustomProgram(M):
             integral=sysData[M]['Custom']['param3']+error*KI
             green=balance+KP*error+integral
             sysData[M]['Custom']['param3']=integral
-        
+
 
         GreenThread=Thread(target = CustomLEDCycle, args=(M,'LEDD',green))
         GreenThread.setDaemon(True)
@@ -1213,7 +1213,7 @@ def CustomProgram(M):
 
     elif (program=="C2"): #UV Integral Control Program
         integral=0.0 #Integral in integral controller
-        UV=0.0 #Intensity of Green actuation 
+        UV=0.0 #Intensity of Green actuation
         GrowthRate=sysData[M]['GrowthRate']['current']
         GrowthTarget=sysData[M]['Custom']['Status'] #This is the controller setpoint.
         error=GrowthTarget-GrowthRate
@@ -1229,7 +1229,7 @@ def CustomProgram(M):
         SetOutputOn(M,'UV',1)
         addTerminal(M, 'Program on %s (%s)= %s UV= %s integral= %s'
                     % (M, sysData[M]['DeviceID'], str(program), str(UV), str(integral)))
-        
+
     elif (program=="C3"): #UV Integral Control Program Mk 2
         integral=sysData[M]['Custom']['param2'] #Integral in integral controller
         integral2=sysData[M]['Custom']['param3'] #Second integral controller
@@ -1243,12 +1243,12 @@ def CustomProgram(M):
         integral=sysData[M]['Custom']['param2']+error*KI
         if(integral>0):
             integral=0.0
-            
+
         if(abs(error)<0.3): #This is a second high-gain integrator which only gets cranking along when we are close to the target.
             integral2=sysData[M]['Custom']['param3']+error*KI2
         if(integral2>0):
             integral2=0.0
-            
+
         sysData[M]['Custom']['param2']=integral
         sysData[M]['Custom']['param3']=integral2
         UV=-1.0*(KP*error+integral+integral2)
@@ -1260,24 +1260,24 @@ def CustomProgram(M):
         addTerminal(M,'Program on %s (%s) = %s UV= %s integral= %s'
                     % (M, sysData[M]['DeviceID'], str(program), str(UV), str(integral)))
     elif (program=="C4"): #UV Integral Control Program Mk 4
-        rategain=float(Params[0]) 
+        rategain=float(Params[0])
         timept=sysData[M]['Custom']['Status'] #This is the timestep as we follow in minutes
-        
+
         UV=0.001*math.exp(timept*rategain) #So we just exponentialy increase UV over time!
         sysData[M]['Custom']['param1']=UV
         SetOutputTarget(M,'UV',UV)
         SetOutputOn(M,'UV',1)
-        
+
         timept=timept+1
         sysData[M]['Custom']['Status']=timept
-            
+
     elif (program=="C5"): #UV Dosing program
         timept=int(sysData[M]['Custom']['Status']) #This is the timestep as we follow in minutes
         sysData[M]['Custom']['Status']=timept+1 #Increment time as we have entered the loop another time!
-        
+
         Pump2Ontime=sysData[M]['Experiment']['cycleTime']*1.05*abs(sysData[M]['Pump2']['target'])*sysData[M]['Pump2']['ON']+0.5 #The amount of time Pump2 is going to be on for following RegulateOD above.
         time.sleep(Pump2Ontime) #Pause here is to prevent output pumping happening at the same time as stirring.
-        
+
         timelength=300 #Time between doses in minutes
         if(timept%timelength==2): #So this happens every 5 hours!
             iters=(timept//timelength)
@@ -1285,49 +1285,49 @@ def CustomProgram(M):
             Dose=Dose0*(2.0**float(iters)) #UV Dose, in terms of amount of time UV shoudl be left on at 1.0 intensity.
             addTerminal(M, 'Gave dose %s at iteration %s on device %s (%s)'
                         % (str(Dose), str(iters), M, sysData[M]['DeviceID']))
-            
-            if (Dose<30.0):  
+
+            if (Dose<30.0):
                 powerlvl=Dose/30.0
                 SetOutputTarget(M,'UV',powerlvl)
                 Dose=30.0
-            else:    
+            else:
                 SetOutputTarget(M,'UV',1.0) #Ensure UV is on at aopropriate intensity
-                
+
             SetOutputOn(M,'UV',1) #Activate UV
             time.sleep(Dose) #Wait for dose to be administered
             SetOutputOn(M,'UV',0) #Deactivate UV
-            
+
     elif (program=="C6"): #UV Dosing program 2 - constant value!
         timept=int(sysData[M]['Custom']['Status']) #This is the timestep as we follow in minutes
         sysData[M]['Custom']['Status']=timept+1 #Increment time as we have entered the loop another time!
-        
+
         Pump2Ontime=sysData[M]['Experiment']['cycleTime']*1.05*abs(sysData[M]['Pump2']['target'])*sysData[M]['Pump2']['ON']+0.5 #The amount of time Pump2 is going to be on for following RegulateOD above.
         time.sleep(Pump2Ontime) #Pause here is to prevent output pumping happening at the same time as stirring.
-    
+
         timelength=300 #Time between doses in minutes
         if(timept%timelength==2): #So this happens every 5 hours!
             iters=(timept//timelength)
             if iters>3:
                 iters=3
-                
+
             Dose0=float(Params[0])
             Dose=Dose0*(2.0**float(iters)) #UV Dose, in terms of amount of time UV shoudl be left on at 1.0 intensity.
             addTerminal(M, 'Gave dose %s at iteration %s on device %s (%s)'
                         % (str(Dose), str(iters), M, sysData[M]['DeviceID']))
-              
-            if (Dose<30.0):  
+
+            if (Dose<30.0):
                 powerlvl=Dose/30.0
                 SetOutputTarget(M,'UV',powerlvl)
                 Dose=30.0
-            else:    
+            else:
                 SetOutputTarget(M,'UV',1.0) #Ensure UV is on at aopropriate intensity
-            
+
             SetOutputOn(M,'UV',1) #Activate UV
             time.sleep(Dose) #Wait for dose to be administered
             SetOutputOn(M,'UV',0) #Deactivate UV
-                
-                
-    
+
+
+
     return
 
 def CustomLEDCycle(M,LED,Value):
@@ -1336,15 +1336,15 @@ def CustomLEDCycle(M,LED,Value):
     M=str(M)
     if (Value>1.0):
         Value=1.0
-        
+
     if (Value>0.0):
         SetOutputOn(M,LED,1)
         time.sleep(Value*30.0)#Sleep whatever fraction of 30 seconds we are interested in
         SetOutputOn(M,LED,0)
-        
+
     return
 
-        
+
 
 @application.route("/SetLightActuation/<Excite>",methods=['POST'])
 def SetLightActuation(Excite):
@@ -1359,9 +1359,9 @@ def SetLightActuation(Excite):
         sysData[M][item]['Excite']=str(Excite)
         sysData[M][item]['ON']=1
         return('',204)
-        
-        
-        
+
+
+
 def LightActuation(M,toggle):
     #Another optogenetic function, turning LEDs on/off during experiment as appropriate.
     global sysData
@@ -1375,19 +1375,19 @@ def LightActuation(M,toggle):
     return 0
 
 
-@application.route("/CharacteriseDevice/<M>/<Program>",methods=['POST'])     
-def CharacteriseDevice(M,Program): 
+@application.route("/CharacteriseDevice/<M>/<Program>",methods=['POST'])
+def CharacteriseDevice(M,Program):
     # THis umbrella function is used to run the actual characteriseation function in a thread to prevent GUnicorn worker timeout.
     Program=str(Program)
     if (Program=='C1'):
         cthread=Thread(target = CharacteriseDevice2, args=(M))
         cthread.setDaemon(True)
         cthread.start()
-    
+
     return('',204)
-        
-        
-        
+
+
+
 def CharacteriseDevice2(M):
     global sysData
     global sysItems
@@ -1395,7 +1395,7 @@ def CharacteriseDevice2(M):
     M=str(M)
     if (M=="0"):
         M=sysItems['UIDevice']
-        
+
     result= { 'LEDA' : {'nm410' : [],'nm440' : [],'nm470' : [],'nm510' : [],'nm550' : [],'nm583' : [],'nm620' : [],'nm670' : [],'CLEAR' : []},
         'LEDB' : {'nm410' : [],'nm440' : [],'nm470' : [],'nm510' : [],'nm550' : [],'nm583' : [],'nm620' : [],'nm670' : [],'CLEAR' : []},
         'LEDC' : {'nm410' : [],'nm440' : [],'nm470' : [],'nm510' : [],'nm550' : [],'nm583' : [],'nm620' : [],'nm670' : [],'CLEAR' : []},
@@ -1405,10 +1405,10 @@ def CharacteriseDevice2(M):
         'LEDG' : {'nm410' : [],'nm440' : [],'nm470' : [],'nm510' : [],'nm550' : [],'nm583' : [],'nm620' : [],'nm670' : [],'CLEAR' : []},
         'LASER650' : {'nm410' : [],'nm440' : [],'nm470' : [],'nm510' : [],'nm550' : [],'nm583' : [],'nm620' : [],'nm670' : [],'CLEAR' : []},
         }
-        
-        
-    print('Got in!')   
-    bands=['nm410' ,'nm440','nm470','nm510','nm550','nm583','nm620','nm670','CLEAR']    
+
+
+    print('Got in!')
+    bands=['nm410' ,'nm440','nm470','nm510','nm550','nm583','nm620','nm670','CLEAR']
     powerlevels=[0,0.01,0.02,0.03,0.04,0.05,0.06,0.07,0.08,0.09,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0]
     items= ['LEDA','LEDB','LEDC','LEDD','LEDE','LEDF','LEDG','LASER650']
     gains=['x4','x4','x4','x4','x4','x4','x4','x1']
@@ -1433,9 +1433,9 @@ def CharacteriseDevice2(M):
     f.close()
     return
 
-  
-        
-        
+
+
+
 
 def I2CCom(M,device,rw,hl,data1,data2,SMBUSFLAG):
     #Function used to manage I2C bus communications for ALL devices.
@@ -1444,12 +1444,12 @@ def I2CCom(M,device,rw,hl,data1,data2,SMBUSFLAG):
     rw=int(rw) #1 if read, 0 if write
     hl=int(hl) #8 or 16
     SMBUSFLAG=int(SMBUSFLAG) # If this flag is set to 1 it means we are communuicating with an SMBUs device.
-    data1=int(data1) #First data/register 
+    data1=int(data1) #First data/register
     if hl<20:
-        data2=int(data2) #First data/register 
+        data2=int(data2) #First data/register
     global sysItems
     global sysData
-    
+
     global sysDevices
     if(sysData[M]['present']==0): #Something stupid has happened in software if this is the case!
         critical_msg = ' Trying to communicate with %s (%s) absent device - bug in software!. ' \
@@ -1460,17 +1460,17 @@ def I2CCom(M,device,rw,hl,data1,data2,SMBUSFLAG):
         out=0
         tries=-1
         os._exit(4)
-    
+
     #cID=str(M)+str(device)+'d'+str(data1)+'d'+str(data2)  # This is an ID string for the communication that we are trying to send - not used at present
-    #Any time a thread gets to this point it will wait until the lock is free. Then, only one thread at a time will advance. 
+    #Any time a thread gets to this point it will wait until the lock is free. Then, only one thread at a time will advance.
     lock.acquire()
 
-    
+
     #We now connect the multiplexer to the appropriate device to allow digital communications.
     tries=0
     while(tries!=-1):
         try:
-            sysItems['Multiplexer']['device'].write8(int(0x00),int(sysItems['Multiplexer'][M],2)) #We have established connection to correct device. 
+            sysItems['Multiplexer']['device'].write8(int(0x00),int(sysItems['Multiplexer'][M],2)) #We have established connection to correct device.
             check=(sysItems['Multiplexer']['device'].readRaw8()) #We check that the Multiplexer is indeed connected to the correct channel.
             if(check==int(sysItems['Multiplexer'][M],2)):
                 tries=-1
@@ -1502,9 +1502,9 @@ def I2CCom(M,device,rw,hl,data1,data2,SMBUSFLAG):
                     application.logger.warning(warn_msg)
             if tries==5:
                 time.sleep(0.2)
-                
+
         if tries>20: #If it has failed a number of times then likely something is seriously wrong, so we crash the software.
-            sysItems['Watchdog']['ON']=0 #Basically this will crash all the electronics and the software. 
+            sysItems['Watchdog']['ON']=0 #Basically this will crash all the electronics and the software.
             out=0
             critical_msg = 'Failed to communicate to Multiplexer %d times on %s (%s).Disabling hardware and software!' \
                            % (20, M, sysData[M]['DeviceID'])
@@ -1512,14 +1512,14 @@ def I2CCom(M,device,rw,hl,data1,data2,SMBUSFLAG):
             application.logger.critical(critical_msg)
             tries=-1
             os._exit(4)
-    
-    
 
-    
+
+
+
     time.sleep(0.0005)
     out=0;
     tries=0
-    
+
     while(tries!=-1): #We now do appropriate read/write on the bus.
         try:
             if SMBUSFLAG==0:
@@ -1535,13 +1535,13 @@ def I2CCom(M,device,rw,hl,data1,data2,SMBUSFLAG):
                     elif(hl==16):
                         sysDevices[M][device]['device'].write16(data1,data2)
                         out=1
-                    
+
             elif SMBUSFLAG==1:
                 out=sysDevices[M][device]['device'].read_word_data(sysDevices[M][device]['address'],data1)
             tries=-1
         except: #If the above fails then we can try again (a limited number of times)
             tries=tries+1
-            
+
             if (device!="ThermometerInternal"):
                 warn_msg = 'Failed %s comms %d times on %s (%s)' % (device, tries, M, sysData[M]['DeviceID'])
                 print(str(datetime.now()) + warn_msg)
@@ -1560,7 +1560,7 @@ def I2CCom(M,device,rw,hl,data1,data2,SMBUSFLAG):
             sysData[M]['present']=0
             tries=-1
         if tries >= application.config['DEVICE_COMM_FAILURE_THRESHOLD']: #In this case something else has gone wrong, so we panic.
-            sysItems['Watchdog']['ON']=0 #Basically this will crash all the electronics and the software. 
+            sysItems['Watchdog']['ON']=0 #Basically this will crash all the electronics and the software.
             out=0
             sysData[M]['present']=0
             critical_msg = 'Failed to communicate to %s %d times on %s (%s). Disabling hardware and software!' \
@@ -1569,26 +1569,26 @@ def I2CCom(M,device,rw,hl,data1,data2,SMBUSFLAG):
             application.logger.critical(critical_msg)
             tries=-1
             os._exit(4)
-                
-    time.sleep(0.0005)
-    
 
-    
+    time.sleep(0.0005)
+
+
+
     try:
-        sysItems['Multiplexer']['device'].write8(int(0x00),int(0x00)) #Disconnect multiplexer with each iteration. 
+        sysItems['Multiplexer']['device'].write8(int(0x00),int(0x00)) #Disconnect multiplexer with each iteration.
     except:
         warn_msg = 'Failed to disconnect multiplexer on device %s (%s)' % (M, sysData[M]['DeviceID'])
         print(warn_msg)
         application.logger.warning(warn_msg)
 
 
-    
+
     lock.release() #Bus lock is released so next command can occur.
-    
+
     return(out)
-    
-    
-    
+
+
+
 
 @application.route("/CalibrateOD/<item>/<M>/<value>/<value2>",methods=['POST'])
 def CalibrateOD(M,item,value,value2):
@@ -1600,15 +1600,15 @@ def CalibrateOD(M,item,value,value2):
     M=str(M)
     if (M=="0"):
         M=sysItems['UIDevice']
-        
+
     device=sysData[M]['OD']['device']
     if (device=='LASER650'):
         a=sysData[M]['OD0']['LASERa']#Retrieve the calibration factors for OD.
-        b=sysData[M]['OD0']['LASERb'] 
+        b=sysData[M]['OD0']['LASERb']
         if (ODActual<0):
             ODActual=0
             print("You put a negative OD into calibration! Setting it to 0")
-        
+
         raw=((ODActual/a +  (b/(2*a))**2)**0.5) - (b/(2*a)) #THis is performing the inverse function of the quadratic OD calibration.
         OD0=(10.0**raw)*ODRaw
         if (OD0<sysData[M][item]['min']):
@@ -1619,14 +1619,14 @@ def CalibrateOD(M,item,value,value2):
             OD0=sysData[M][item]['max']
             print('OD calibration value seems too high?!')
 
-    
+
         sysData[M][item]['target']=OD0
         info_msg = "Calibrated OD on %s (%s)" % (M, sysData[M]['DeviceID'])
         print(info_msg)
         application.logger.info(info_msg)
     elif (device=='LEDF'):
         a=sysData[M]['OD0']['LEDFa']#Retrieve the calibration factors for OD.
-        
+
         if (ODActual<0):
             ODActual=0
             print("You put a negative OD into calibration! Setting it to 0")
@@ -1638,26 +1638,26 @@ def CalibrateOD(M,item,value,value2):
             CF=1660.0
         elif (M=='M3'):
             CF=1494.0
-            
+
         raw=(ODActual)/a  #THis is performing the inverse function of the linear OD calibration.
         OD0=ODRaw - raw*CF
         OD0=ODRaw/ODActual
         print(OD0)
-    
+
         if (OD0<sysData[M][item]['min']):
             OD0=sysData[M][item]['min']
             print('OD calibration value seems too low?!')
         if (OD0>sysData[M][item]['max']):
             OD0=sysData[M][item]['max']
             print('OD calibration value seems too high?!')
-    
+
         sysData[M][item]['target']=OD0
         info_msg = "Calibrated OD on %s (%s)" % (M, sysData[M]['DeviceID'])
         print(info_msg)
         application.logger.info(info_msg)
     elif (device=='LEDA'):
         a=sysData[M]['OD0']['LEDAa']#Retrieve the calibration factors for OD.
-        
+
         if (ODActual<0):
             ODActual=0
             print("You put a negative OD into calibration! Setting it to 0")
@@ -1669,25 +1669,25 @@ def CalibrateOD(M,item,value,value2):
             CF=574
         elif (M=='M3'):
             CF=522
-            
+
         raw=(ODActual)/a  #THis is performing the inverse function of the linear OD calibration.
         OD0=ODRaw - raw*CF
         OD0=ODRaw/ODActual
         print(OD0)
-    
+
         if (OD0<sysData[M][item]['min']):
             OD0=sysData[M][item]['min']
             print('OD calibration value seems too low?!')
         if (OD0>sysData[M][item]['max']):
             OD0=sysData[M][item]['max']
             print('OD calibration value seems too high?!')
-    
+
         sysData[M][item]['target']=OD0
         info_msg = "Calibrated OD on %s (%s)" % (M, sysData[M]['DeviceID'])
         print(info_msg)
         application.logger.info(info_msg)
-        
-    return ('', 204)    
+
+    return ('', 204)
 
 
 @application.route("/SampleOD/<M>/<value>",methods=['POST'])
@@ -1748,9 +1748,9 @@ def MeasureOD(M):
     if (device=='LASER650'):
         out=GetTransmission(M,'LASER650',['CLEAR'],1,255)
         sysData[M]['OD0']['raw']=float(out[0])
-    
+
         a=sysData[M]['OD0']['LASERa']#Retrieve the calibration factors for OD.
-        b=sysData[M]['OD0']['LASERb'] 
+        b=sysData[M]['OD0']['LASERb']
         try:
             raw=math.log10(sysData[M]['OD0']['target']/sysData[M]['OD0']['raw'])
             sysData[M]['OD']['current']=raw*b + raw*raw*a
@@ -1805,11 +1805,11 @@ def MeasureOD(M):
             warn_msg = ' OD Measurement exception on %s (%s) device: %s' % (M, sysData[M]['DeviceID'], str(device))
             print(str(datetime.now()) + warn_msg)
             application.logger.warning(warn_msg)
-    
-    return ('', 204)  
-    
 
-@application.route("/MeasureFP/<M>",methods=['POST'])    
+    return ('', 204)
+
+
+@application.route("/MeasureFP/<M>",methods=['POST'])
 def MeasureFP(M):
     #Responsible for measuring each of the active Fluorescent proteins.
     global sysData
@@ -1824,25 +1824,25 @@ def MeasureFP(M):
             if (sysData[M][FP]['Base']>0):
                 sysData[M][FP]['Emit1']=float(out[1])/sysData[M][FP]['Base']
                 sysData[M][FP]['Emit2']=float(out[2])/sysData[M][FP]['Base']
-            else:#This might happen if you try to measure in CLEAR whilst also having CLEAR as baseband! 
-                sysData[M][FP]['Emit1']=float(out[1]) 
+            else:#This might happen if you try to measure in CLEAR whilst also having CLEAR as baseband!
+                sysData[M][FP]['Emit1']=float(out[1])
                 sysData[M][FP]['Emit2']=float(out[2])
 
             # saving the unnormalized emissions
             sysData[M][FP]['Emit1_raw'] = float(out[1])
             sysData[M][FP]['Emit2_raw'] = float(out[2])
 
-    return ('', 204)      
-    
+    return ('', 204)
 
-    
-    
+
+
+
 @application.route("/MeasureTemp/<which>/<M>",methods=['POST'])
-def MeasureTemp(M,which): 
+def MeasureTemp(M,which):
     #Used to measure temperature from each thermometer.
     global sysData
     global sysItems
-   
+
     if (M=="0"):
         M=sysItems['UIDevice']
     M=str(M)
@@ -1861,11 +1861,11 @@ def MeasureTemp(M,which):
     if temperature>100.0:#It seems sometimes the IR thermometer returns a value of 1000 due to an error. This prevents that.
         temperature=sysData[M][which]['current']
     sysData[M][which]['current']=temperature
-    return ('', 204) 
-    
+    return ('', 204)
 
 
-    
+
+
 def setPWM(M,device,channels,fraction,ConsecutiveFails):
     #Sets up the PWM chip (either the one in the reactor or on the pump board)
     global sysItems
@@ -1873,27 +1873,27 @@ def setPWM(M,device,channels,fraction,ConsecutiveFails):
                             (M, sysData[M]['DeviceID'], device, channels, fraction, ConsecutiveFails))
     if sysDevices[M][device]['startup']==0: #The following boots up the respective PWM device to the correct frequency. Potentially there is a bug here; if the device loses power after this code is run for the first time it may revert to default PWM frequency.
         I2CCom(M,device,0,8,0x00,0x11,0) #Turns off device.
-        I2CCom(M,device,0,8,0xfe,sysDevices[M][device]['frequency'],0) #Sets frequency of PWM oscillator. 
+        I2CCom(M,device,0,8,0xfe,sysDevices[M][device]['frequency'],0) #Sets frequency of PWM oscillator.
         sysDevices[M][device]['startup']=1
-    I2CCom(M,device,0,8,0x00,0x01,0) #Turns device on for sure! 
-        
-    
+    I2CCom(M,device,0,8,0x00,0x01,0) #Turns device on for sure!
+
+
     timeOn=int(fraction*4095.99)
     I2CCom(M,device,0,8,channels['ONL'],0x00,0)
     I2CCom(M,device,0,8,channels['ONH'],0x00,0)
-    
+
     OffVals=bin(timeOn)[2:].zfill(12)
     HighVals='0000' + OffVals[0:4]
     LowVals=OffVals[4:12]
-    
+
     I2CCom(M,device,0,8,channels['OFFL'],int(LowVals,2),0)
     I2CCom(M,device,0,8,channels['OFFH'],int(HighVals,2),0)
-    
+
     CheckLow=I2CCom(M,device,1,8,channels['OFFL'],-1,0)
     CheckHigh=I2CCom(M,device,1,8,channels['OFFH'],-1,0)
     CheckLowON=I2CCom(M,device,1,8,channels['ONL'],-1,0)
     CheckHighON=I2CCom(M,device,1,8,channels['ONH'],-1,0)
-    
+
     if(CheckLow!=(int(LowVals,2)) or CheckHigh!=(int(HighVals,2)) or CheckHighON!=int(0x00) or CheckLowON!=int(0x00)): #We check to make sure it has been set to appropriate values.
         ConsecutiveFails=ConsecutiveFails+1
         warn_msg = ' Failed transmission test on %s %d times consecutively on device %s (%s)' % \
@@ -1911,7 +1911,7 @@ def setPWM(M,device,channels,fraction,ConsecutiveFails):
             time.sleep(0.1)
             sysItems['FailCount']=sysItems['FailCount']+1
             setPWM(M,device,channels,fraction,ConsecutiveFails)
-    
+
 
 
 
@@ -1957,7 +1957,7 @@ def csvData(M):
             row=row+[sysData[M][FP]['Emit2_raw']]
         else:
             row=row+([0.0, 0.0, 0.0, 0.0, 0.0])
-    
+
     row=row+[sysData[M]['Custom']['param1']*float(sysData[M]['Custom']['ON'])]
     row=row+[sysData[M]['Custom']['param2']*float(sysData[M]['Custom']['ON'])]
     row=row+[sysData[M]['Custom']['param3']*float(sysData[M]['Custom']['ON'])]
@@ -1965,10 +1965,10 @@ def csvData(M):
     row=row+[sysData[M]['Zigzag']['target']*float(sysData[M]['Zigzag']['ON'])]
     row=row+[sysData[M]['GrowthRate']['current']*sysData[M]['Zigzag']['ON']]
     row=row+[sysData[M]['OD0']['raw']]
-   
-   
+
+
     #Following can be uncommented if you are recording ALL spectra for e.g. biofilm experiments
-    #bands=['nm410' ,'nm440','nm470','nm510','nm550','nm583','nm620','nm670','CLEAR','NIR']    
+    #bands=['nm410' ,'nm440','nm470','nm510','nm550','nm583','nm620','nm670','CLEAR','NIR']
     #items= ['LEDA','LEDB','LEDC','LEDD','LEDE','LEDF','LEDG','LASER650']
     #for item in items:
     #   for band in bands:
@@ -1989,24 +1989,24 @@ def csvData(M):
     with open(filename, 'a') as csvFile: # Here we append the above row to our CSV file.
         writer = csv.writer(csvFile)
         writer.writerow(row)
-    csvFile.close()        
-    lock.release() 
-    
+    csvFile.close()
+    lock.release()
+
 
 def downsample(M):
     #In order to prevent the UI getting too laggy, we downsample the stored data every few hours. Note that this doesnt downsample that which has already been written to CSV, so no data is ever lost.
     global sysData
     M=str(M)
-    
-    
-    
-    
+
+
+
+
     #We now generate a new time vector which is downsampled at half the rate of the previous one
     time=np.asarray(sysData[M]['time']['record'])
     newlength=int(round(len(time)/2,2)-1)
     tnew=np.linspace(time[0],time[-11],newlength)
     tnew=np.concatenate([tnew,time[-10:]])
-    
+
     #In the following we make a new array, index, which has the indices at which we want to resample our existing data vectors.
     i=0
     index=np.zeros((len(tnew),),dtype=int)
@@ -2017,8 +2017,8 @@ def downsample(M):
         else:
             index[i]=idx
         i=i+1
-    
- 
+
+
     sysData[M]['time']['record']=downsampleFunc(sysData[M]['time']['record'],index)
     sysData[M]['OD']['record']=downsampleFunc(sysData[M]['OD']['record'],index)
     sysData[M]['OD']['targetrecord']=downsampleFunc(sysData[M]['OD']['targetrecord'],index)
@@ -2032,13 +2032,13 @@ def downsample(M):
     sysData[M]['Pump3']['record']=downsampleFunc(sysData[M]['Pump3']['record'],index)
     sysData[M]['Pump4']['record']=downsampleFunc(sysData[M]['Pump4']['record'],index)
     sysData[M]['GrowthRate']['record']=downsampleFunc(sysData[M]['GrowthRate']['record'],index)
-    
-        
+
+
     for FP in ['FP1','FP2','FP3']:
         sysData[M][FP]['BaseRecord']=downsampleFunc(sysData[M][FP]['BaseRecord'],index)
         sysData[M][FP]['Emit1Record']=downsampleFunc(sysData[M][FP]['Emit1Record'],index)
         sysData[M][FP]['Emit2Record']=downsampleFunc(sysData[M][FP]['Emit2Record'],index)
-        
+
 def downsampleFunc(datain,index):
     #This function Is used to downsample the arrays, taking the points selected by the index vector.
     datain=list(datain)
@@ -2048,11 +2048,11 @@ def downsampleFunc(datain,index):
     i=0
     for loc in list(index):
         newdata[i]=datain[int(loc)]
-        
+
         i=i+1
     return list(newdata)
-    
-        
+
+
 
 
 
@@ -2061,27 +2061,27 @@ def RegulateOD(M):
     global sysData
     global sysItems
     M=str(M)
-    
+
     if (sysData[M]['Zigzag']['ON']==1):
         TargetOD=sysData[M]['OD']['target']
-        Zigzag(M) #Function that calculates new target pump rates, and sets pumps to desired rates. 
+        Zigzag(M) #Function that calculates new target pump rates, and sets pumps to desired rates.
 
-    
+
     Pump1Current=abs(sysData[M]['Pump1']['target'])
     Pump2Current=abs(sysData[M]['Pump2']['target'])
     Pump1Direction=sysData[M]['Pump1']['direction']
     Pump2Direction=sysData[M]['Pump2']['direction']
-    
-    
-    
+
+
+
     ODNow=sysData[M]['OD']['current']
     ODTarget=sysData[M]['OD']['target']
     if (ODTarget<=0): #There could be an error on the log operationif ODTarget is 0!
         ODTarget=0.000001
-        
+
     errorTerm=ODTarget-ODNow
     Volume=sysData[M]['Volume']['target']
-    
+
     PercentPerMin=4*60/Volume #Gain parameter to convert from pump rate to rate of OD reduction.
 
     if sysData[M]['Experiment']['cycles']<3:
@@ -2096,9 +2096,9 @@ def RegulateOD(M):
                 NewGrowth=0.0
         else:
             NewGrowth=0.0
-            
+
         Pump1=-1.0*NewGrowth/PercentPerMin
-        
+
         #Next Section is Integral Control
         ODerror=ODNow-ODTarget
         # Integrator 1 - resoponsible for short-term integration to overcome troubles if an input pump makes a poor seal.
@@ -2108,7 +2108,7 @@ def RegulateOD(M):
         elif (abs(ODNow-ODPast)<0.05 and ODerror>0.025): #preventing massive accidental jumps causing trouble with this integral term.
             ODIntegral=ODIntegral+0.1*ODerror
         sysData[M]['OD']['Integral']=ODIntegral
-        # Integrator 2 
+        # Integrator 2
         ODIntegral2=sysData[M]['OD']['Integral2']
         if (abs(ODerror)>0.1 and abs(ODNow-ODPast)<0.05):
             ODIntegral2=0
@@ -2116,9 +2116,9 @@ def RegulateOD(M):
             ODIntegral2=ODIntegral2+0.01*ODerror
             Pump1=Pump1*0.7 #This is essentially enforcing a smaller Proportional gain when we are near to OD setpoint.
         sysData[M]['OD']['Integral2']=ODIntegral2
-        
+
         Pump1=Pump1+ODIntegral+ODIntegral2
-        
+
         if (ODNow-ODPast)>0.04: #This is to counteract noisy jumps in OD measurements from causing mayhem in the regulation algorithm.
             Pump1=0.0
 
@@ -2137,35 +2137,35 @@ def RegulateOD(M):
 
     if(sysData[M]['Experiment']['cycles']%5==1): #Every so often we do a big output pump to make sure tubes are clear.
         sysData[M]['Pump2']['target']=0.25*sysData[M]['Pump2']['direction']
-    
-    
-    
-    
+
+
+
+
     if (sysData[M]['Experiment']['cycles']>15):
         #This section is to check if we have added any liquid recently, if not, then we dont run pump 2 since it won't be needed.
         pastpumping=abs(sysData[M]['Pump1']['target'])
         for pv in range(-10,-1):
             pastpumping=pastpumping+abs(sysData[M]['Pump1']['record'][pv])
-        
+
         if pastpumping==0.0:
             sysData[M]['Pump2']['target']=0.0
             sysData[M]['Pump1']['target']=0.0 #This should be equal to 0 anyway.
-        
-        
+
+
 
     SetOutputOn(M,'Pump1',1)
     SetOutputOn(M,'Pump2',1)
 
-        
+
     if (sysData[M]['Zigzag']['ON']==1): #If the zigzag growth estimation is running then we change OD setpoint appropriately.
         try:
             sysData[M]['OD']['target']=TargetOD
         except:
             print('Somehow you managed to activate Zigzag at a sub-optimal time')
             #Do nothing
- 
+
     return
-    
+
 def Zigzag(M):
     #This function dithers OD in a "zigzag" pattern, and estimates growthrate. This function is only called when ZigZag mode is active.
     global sysData
@@ -2175,12 +2175,12 @@ def Zigzag(M):
     current=sysData[M]['OD']['current']
     zig=sysData[M]['Zigzag']['Zig']
     iteration=sysData[M]['Experiment']['cycles']
-	
+
     try:
         last=sysData[M]['OD']['record'][-1]
     except: #This will happen if you activate Zigzag in first control iteration!
         last=current
-    
+
     if (current<centre-zig and last<centre):
         if(sysData[M]['Zigzag']['target']!=5.0):
             sysData[M]['Zigzag']['SwitchPoint']=iteration
@@ -2190,9 +2190,9 @@ def Zigzag(M):
         sysData[M]['Zigzag']['SwitchPoint']=iteration
 
     sysData[M]['OD']['target']=sysData[M]['Zigzag']['target']
-	
+
     #Subsequent section is for growth estimation.
-	
+
     TimeSinceSwitch=iteration-sysData[M]['Zigzag']['SwitchPoint']
     if (iteration>6 and TimeSinceSwitch>5): #The reason we wait a few minutes after starting growth is that new media may still be introduced, it takes a while for the growth to get going.
         dGrowthRate=(math.log(current)-math.log(last))*60.0 #Converting to units of 1/hour
@@ -2206,25 +2206,25 @@ def Zigzag(M):
 def ExperimentReset():
     #Resets parameters/values of a given experiment.
     initialise(sysItems['UIDevice'])
-    return ('', 204)   
+    return ('', 204)
 
 @application.route("/Experiment/<value>/<M>",methods=['POST'])
 def ExperimentStartStop(M,value):
-    #Stops or starts an experiment. 
+    #Stops or starts an experiment.
     global sysData
     global sysDevices
     global sysItems
     M=str(M)
     if (M=="0"):
         M=sysItems['UIDevice']
-       
+
     value=int(value)
     #Turning it on involves keeping current pump directions,
     if (value and (sysData[M]['Experiment']['ON']==0)):
-        
+
         sysData[M]['Experiment']['ON']=1
         addTerminal(M, 'Experiment on %s (%s) Started' % (M, sysData[M]['DeviceID']))
-        
+
         if (sysData[M]['Experiment']['cycles']==0):
             now=datetime.now()
             timeString=now.strftime("%Y-%m-%d %H:%M:%S")
@@ -2237,17 +2237,17 @@ def ExperimentStartStop(M,value):
             application.logger.info('Experiment ID: %s has been assign to %s (%s)' %
                                     (sysData[M]['Experiment']['experimentID'], M, sysData[M]['DeviceID']))
             sysData[M]['Experiment']['startTimeRaw']=now
-        
+
         sysData[M]['Pump1']['direction']=1.0 #Sets pumps to go forward.
         sysData[M]['Pump2']['direction']=1.0
 
         turnEverythingOff(M)
-        
+
         SetOutputOn(M,'Thermostat',1)
         sysDevices[M]['Experiment']=Thread(target = runExperiment, args=(M,'placeholder'))
         sysDevices[M]['Experiment'].setDaemon(True)
         sysDevices[M]['Experiment'].start();
-        
+
     else:
         sysData[M]['Experiment']['ON']=0
         sysData[M]['OD']['ON']=0
@@ -2256,22 +2256,22 @@ def ExperimentStartStop(M,value):
         SetOutputOn(M,'Pump2',0)
         SetOutputOn(M,'Stir',0)
         SetOutputOn(M,'Thermostat',0)
-        
+
     return ('', 204)
-    
-    
-    
+
+
+
 def runExperiment(M,placeholder):
     #Primary function for running an automated experiment.
     M=str(M)
-   
+
     global sysData
     global sysItems
     global sysDevices
-    
+
     sysData[M]['Experiment']['threadCount']=(sysData[M]['Experiment']['threadCount']+1)%100
     currentThread=sysData[M]['Experiment']['threadCount']
-        
+
     # Get time running in seconds
     now=datetime.now()
     elapsedTime=now-sysData[M]['Experiment']['startTimeRaw']
@@ -2286,7 +2286,7 @@ def runExperiment(M,placeholder):
         turnEverythingOff(M)
         addTerminal(M, 'Experiment on %s (%s) Stopped' % (M, sysData[M]['DeviceID']))
         return
-    
+
     sysData[M]['OD']['Measuring']=1 #Begin measuring - this flag is just to indicate that a measurement is currently being taken.
 
     # We now measure OD N times and take the average to reduce noise when in auto mode!
@@ -2303,11 +2303,11 @@ def runExperiment(M,placeholder):
     MeasureTemp(M,'Internal') #Measuring all temperatures
     MeasureTemp(M,'External')
     MeasureTemp(M,'IR')
-    MeasureFP(M) #And now fluorescent protein concentrations. 
-    
+    MeasureFP(M) #And now fluorescent protein concentrations.
+
     #Temporary Biofilm Section - the below makes the device all spectral data for all LEDs each cycle.
-    
-    # bands=['nm410' ,'nm440','nm470','nm510','nm550','nm583','nm620','nm670','CLEAR','NIR']    
+
+    # bands=['nm410' ,'nm440','nm470','nm510','nm550','nm583','nm620','nm670','CLEAR','NIR']
     # items= ['LEDA','LEDB','LEDC','LEDD','LEDE','LEDF','LEDG','LASER650']
     # gains=['x10','x10','x10','x10','x10','x10','x10','x1']
     # gi=-1
@@ -2321,24 +2321,24 @@ def runExperiment(M,placeholder):
 
     sysData[M]['OD']['Measuring']=0
     if (sysData[M]['OD']['ON']==1):
-        RegulateOD(M) #Function that calculates new target pump rates, and sets pumps to desired rates. 
-    
-    LightActuation(M,1) 
-    
+        RegulateOD(M) #Function that calculates new target pump rates, and sets pumps to desired rates.
+
+    LightActuation(M,1)
+
     if (sysData[M]['Custom']['ON']==1): #Check if we have enabled custom programs
         CustomThread=Thread(target = CustomProgram, args=(M,)) #We run this in a thread in case we are doing something slow, we dont want to hang up the main l00p. The comma after M is to cast the args as a tuple to prevent it iterating over the thread M
         CustomThread.setDaemon(True)
         CustomThread.start();
 
-    
+
     Pump2Ontime=sysData[M]['Experiment']['cycleTime']*1.05*abs(sysData[M]['Pump2']['target'])*sysData[M]['Pump2']['ON']+0.5 #The amount of time Pump2 is going to be on for following RegulateOD above.
     time.sleep(Pump2Ontime) #Pause here is to prevent output pumping happening at the same time as stirring.
-    
+
     SetOutputOn(M,'Stir',1) #Start stirring again.
 
     if(sysData[M]['Experiment']['cycles']%10==9): #Dont want terminal getting unruly, so clear it each 10 rotations.
         clearTerminal(M)
-    
+
     #######Below stores all the results for plotting later
     sysData[M]['time']['record'].append(elapsedTimeSeconds)
     sysData[M]['OD']['record'].append(sysData[M]['OD']['current'])
@@ -2365,18 +2365,18 @@ def runExperiment(M,placeholder):
             sysData[M][FP]['BaseRecord'].append(0.0)
             sysData[M][FP]['Emit1Record'].append(0.0)
             sysData[M][FP]['Emit2Record'].append(0.0)
-    
-    #We  downsample our records such that the size of the data vectors being plot in the web interface does not get unruly. 
+
+    #We  downsample our records such that the size of the data vectors being plot in the web interface does not get unruly.
     if (len(sysData[M]['time']['record'])>200):
         downsample(M)
 
     #### Writing Results to data files
     csvData(M) #This command writes system data to a CSV file for future keeping.
-    #And intermittently write the setup parameters to a data file. 
-    if(sysData[M]['Experiment']['cycles']%10==1): #We only write whole configuration file each 10 cycles since it is not really that important. 
+    #And intermittently write the setup parameters to a data file.
+    if(sysData[M]['Experiment']['cycles']%10==1): #We only write whole configuration file each 10 cycles since it is not really that important.
         TempStartTime=sysData[M]['Experiment']['startTimeRaw']
         sysData[M]['Experiment']['startTimeRaw']=0 #We had to set this to zero during the write operation since the system does not like writing data in such a format.
-        
+
         filename = '%s/%s.txt' % (application.config['DATA_DIR'], sysData[M]['Experiment']['experimentID'])
         with open(filename,'w') as f:
             simplejson.dump(sysData[M], f)
@@ -2387,7 +2387,7 @@ def runExperiment(M,placeholder):
         turnEverythingOff(M)
         addTerminal(M, 'Experiment on %s (%s) Stopped' % (M, sysData[M]['DeviceID']))
         return
-    
+
     nowend=datetime.now()
     elapsedTime2=nowend-now
     elapsedTimeSeconds2=round(elapsedTime2.total_seconds(),2)
@@ -2395,7 +2395,7 @@ def runExperiment(M,placeholder):
     if (sleeptime<0):
         sleeptime=0
         addTerminal(M, 'Experiment Cycle Time on %s (%s) is too short!!!' % (M, sysData[M]['DeviceID']))
-        
+
     time.sleep(sleeptime)
     LightActuation(M,0) #Turn light actuation off if it is running.
     addTerminal(M, 'Cycle %d on %s (%s) Complete' % (sysData[M]['Experiment']['cycles'], M, sysData[M]['DeviceID']))
@@ -2405,16 +2405,16 @@ def runExperiment(M,placeholder):
         sysDevices[M]['Experiment']=Thread(target = runExperiment, args=(M,'placeholder'))
         sysDevices[M]['Experiment'].setDaemon(True)
         sysDevices[M]['Experiment'].start();
-        
-    else: 
+
+    else:
         turnEverythingOff(M)
         addTerminal(M, 'Experiment on %s (%s) Stopped' % (M, sysData[M]['DeviceID']))
-   
+
 
 if __name__ == '__main__':
     initialiseAll()
     application.run(debug=True,threaded=True,host='0.0.0.0',port=5000)
-    
+
 initialiseAll()
 info_msg = ' Start Up Complete'
 application.logger.info(info_msg)

--- a/app.py
+++ b/app.py
@@ -2253,6 +2253,22 @@ def ExperimentReset():
     initialise(sysItems['UIDevice'])
     return ('', 204)
 
+@application.route("/Experiment/<M>", methods=["POST"])
+def CreateExperiment(M):
+    now = datetime.now()
+    experiment_id = createExperiment(M, now)
+
+    return jsonify({"experimentID": experiment_id})
+
+def createExperiment(M, time):
+    time_string = time.strftime("%Y-%m-%d %H:%M:%S")
+    beaglebone_name = application.config["BEAGLEBONE_NAME"]
+    device_id = sysData[M]["DeviceID"]
+    experiment_id = f"{beaglebone_name}_{time_string.replace(':', '_')}_{M}_{device_id}"
+    sysData[M]['Experiment']['experimentID'] = experiment_id
+
+    return experiment_id
+
 @application.route("/Experiment/<value>/<M>",methods=['POST'])
 def ExperimentStartStop(M,value):
     #Stops or starts an experiment.
@@ -2273,11 +2289,8 @@ def ExperimentStartStop(M,value):
             now=datetime.now()
             timeString=now.strftime("%Y-%m-%d %H:%M:%S")
             sysData[M]['Experiment']['startTime']=timeString
-            sysData[M]['Experiment']['experimentID'] = '%s_%s_%s_%s' % \
-                                                       (application.config['BEAGLEBONE_NAME'],
-                                                        sysData[M]['Experiment']['startTime'].replace(":","_"),
-                                                        M,
-                                                        sysData[M]['DeviceID'])
+            if sysData[M]['Experiment']['experimentID'] is None:
+                sysData[M]['Experiment']['experimentID'] = createExperiment(M, now)
             application.logger.info('Experiment ID: %s has been assign to %s (%s)' %
                                     (sysData[M]['Experiment']['experimentID'], M, sysData[M]['DeviceID']))
             sysData[M]['Experiment']['startTimeRaw']=now

--- a/static/HTMLScripts.js
+++ b/static/HTMLScripts.js
@@ -475,7 +475,7 @@ function updateData(data){
 
 
        // Following if statement is for things that should be done only when changing betwix devices.
-        if (document.getElementById("FPRefresh").value != data.UIDevice){
+       // if (document.getElementById("FPRefresh").value != data.UIDevice){
             document.getElementById("FPRefresh").value = data.UIDevice
 
             document.getElementById("FPExcite1").value = data.FP1.LED
@@ -495,7 +495,7 @@ function updateData(data){
             document.getElementById("FPEmit3A").value = data.FP3.Emit1Band
             document.getElementById("FPEmit3B").value = data.FP3.Emit2Band
             document.getElementById("FPGain3").value = data.FP3.Gain
-        }
+        // }
 
         // Now to draw the charts
         if( document.getElementById("GraphReplot").value!== data.time.record.length || document.getElementById("FPRefresh").innerHTML != data.UIDevice){


### PR DESCRIPTION
This PR exposes an endpoint for setting the sysData object directly for a given device, allowing it to be remotely configured via programmatic access.

This PR also adds an endpoint for creating an experiment to be executed. However, it does not start the experiment immediately, still requiring someone to start the experiment manually via the UI.

These features enable the work done in https://github.com/jace-ys/lab-automation to develop lab automation around the ChiBio system, where one can configure experiments remotely as well as retrieve CSV data generated by the ChiBio (the latter still requires the local filesystem to work).

This requires some testing with the actual hardware before it's ready to be merged.